### PR TITLE
Optionally use hash as the source for route.path

### DIFF
--- a/carbon-location.html
+++ b/carbon-location.html
@@ -14,13 +14,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="carbon-location">
   <template>
-    <iron-page-url path="{{__path}}" query="{{__query}}"></iron-page-url>
+    <iron-page-url path="{{__path}}" hash="{{__hash}}" query="{{__query}}"></iron-page-url>
     <iron-query-params
         params-string="{{__query}}"
         params-object="{{__queryParams}}">
     </iron-query-params>
     <carbon-route-converter
-        path="{{__path}}"
+        on-path-changed="__onPathChanged"
+        path="[[__computeRoutePath(__path, __hash, useHashAsPath)]]"
         query-params="{{__queryParams}}"
         route="{{route}}">
     </carbon-route-converter>
@@ -39,6 +40,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         route: {
           type: Object,
           notify: true
+        },
+
+        /**
+         * In many scenarios, it is convenient to treat the `hash` as a stand-in
+         * alternative to the `path`. For example, if deploying an app to a static
+         * web server (e.g., Github Pages) - where one does not have control over
+         * server-side routing - it is usually a better experience to use the hash
+         * to represent paths through one's app.
+         *
+         * When this property is set to true, the `hash` will be used in place of
+         * the `path` for generating a `route`.
+         */
+        useHashAsPath: {
+          type: Boolean,
+          value: false
         },
 
         /**
@@ -61,6 +77,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          */
         __query: {
           type: String
+        },
+
+        /**
+         * The hash portion of the current URL.
+         */
+        __hash: {
+          type: String
+        }
+      },
+
+      __computeRoutePath: function(path, hash, useHashAsPath) {
+        return useHashAsPath ? hash : path;
+      },
+
+      __onPathChanged: function(event) {
+        var path = event.detail.value;
+
+        if (this.useHashAsPath) {
+          this.__hash = path;
+        } else {
+          this.__path = path;
         }
       }
     });

--- a/carbon-route-converter.html
+++ b/carbon-route-converter.html
@@ -91,7 +91,8 @@ turn is consumed by the `carbon-route`.
        */
       path: {
         type: String,
-        notify: true
+        notify: true,
+        value: ''
       }
     },
 
@@ -107,7 +108,7 @@ turn is consumed by the `carbon-route`.
 
     /**
      * Handler called when the path or queryParams change.
-     * 
+     *
      * @param  {!string} path The serialized path through the route tree.
      * @param  {Object} queryParams A set of key/value pairs that are
      * universally accessible to branches of the route tree.
@@ -122,7 +123,7 @@ turn is consumed by the `carbon-route`.
 
     /**
      * Handler called when the route prefix and route path change.
-     * 
+     *
      * @param  {!string} prefix The fragment of the pathname that precedes the
      * path.
      * @param  {!string} path The serialized path through the route tree.
@@ -131,12 +132,13 @@ turn is consumed by the `carbon-route`.
       if (!this.route) {
         return;
       }
+
       this.path = prefix + path;
     },
 
     /**
      * Handler called when the route queryParams change.
-     * 
+     *
      * @param  {Object} queryParams A set of key/value pairs that are
      * universally accessible to branches of the route tree.
      */

--- a/test/app-example-1.html
+++ b/test/app-example-1.html
@@ -8,12 +8,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel='import' href='../carbon-route.html'>
-<link rel='import' href='../carbon-route-converter.html'>
+<link rel='import' href='../carbon-location.html'>
 
 <dom-module id='app-example-1'>
   <template>
-    <carbon-route-converter path='{{path}}' route='{{route}}'>
-    </carbon-route-converter>
+    <carbon-location route='{{route}}'>
+    </carbon-location>
     <carbon-route route='{{route}}' match='/:page' data='{{data}}'>
     </carbon-route>
     <carbon-route route='{{route}}' match='/user' tail='{{userRoute}}'>

--- a/test/carbon-location.html
+++ b/test/carbon-location.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <!--
+@license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
@@ -21,6 +22,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="BasicLocation">
     <template>
       <carbon-location></carbon-location>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="LocationViaHash">
+    <template>
+      <carbon-location use-hash-as-path></carbon-location>
     </template>
   </test-fixture>
 
@@ -118,6 +125,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             fiz: 'buz'
           });
         });
+      });
+    });
+
+    suite('using the hash as the route path', function() {
+      var carbonLocation;
+      var originalLocation;
+
+      setup(function() {
+        originalLocation = window.location.toString();
+      });
+
+      teardown(function() {
+        setLocation(originalLocation);
+      });
+
+      setup(function() {
+        carbonLocation = fixture('LocationViaHash');
+      });
+
+      test('it reflects location.hash to route.path', function() {
+        setLocation('#/fiz/buz');
+        expect(carbonLocation.route.path).to.be.equal('/fiz/buz');
+      });
+
+      test('it reflects route.path to location.hash', function() {
+        carbonLocation.set('route.path', '/foo/bar');
+        expect(window.location.hash).to.be.equal('#/foo/bar');
       });
     });
   </script>

--- a/test/carbon-route-converter.html
+++ b/test/carbon-route-converter.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <!--
+@license
 Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
@@ -28,7 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
-    suite('<carbon-route-converter>', function () {
+    suite('<carbon-route-converter>', function() {
       test('it bidirectionally maps path and queryParams to route', function() {
         var converter = fixture('BasicRouteConversion');
 

--- a/test/test-app-example-1.html
+++ b/test/test-app-example-1.html
@@ -18,15 +18,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="./app-example-1.html">
 </head>
 <body>
+  <test-fixture id="ExampleApp">
+    <template>
+      <app-example-1></app-example-1>
+    </template>
+  </test-fixture>
 <script>
   'use strict';
 
-  suite('<test-app-example-1>', function () {
-    test('does the thing', function() {
-      var exampleApp = document.createElement('app-example-1');
+  function setLocation(url) {
+    window.history.pushState({}, '', url);
+    Polymer.Base.fire('location-changed', {}, { node: window });
+  }
 
+  suite('<test-app-example-1>', function () {
+    var originalLocation;
+    var exampleApp;
+
+    setup(function() {
+      originalLocation = window.location.toString();
+      exampleApp = fixture('ExampleApp');
+    });
+
+    teardown(function() {
+      setLocation(originalLocation);
+    });
+
+    test('runs through basic usage', function() {
       // Navigate to /lol
-      exampleApp.path = '/lol';
+      setLocation('/lol');
+
       expect(exampleApp.data).to.be.deep.eq({
         page: 'lol'
       });
@@ -44,7 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       // Navigate to /user
-      exampleApp.path = '/user';
+      setLocation('/user');
       expect(exampleApp.data).to.be.deep.eq({
         page: 'user'
       });
@@ -60,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       // Navigate to /user/details
-      exampleApp.path = '/user/details';
+      setLocation('/user/details');
       expect(exampleApp.data).to.be.deep.eq({
         page: 'user'
       });
@@ -80,16 +101,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       // Data binding changes to a different user subpage.
       exampleApp.set('userData.page', 'profile');
-      expect(exampleApp.path).to.be.eq('/user/profile');
+      expect(window.location.pathname).to.be.eq('/user/profile');
 
 
       // Data binding changes to the aunt of the current page.
       exampleApp.set('data.page', 'feed');
-      expect(exampleApp.path).to.be.eq('/feed');
+      expect(window.location.pathname).to.be.eq('/feed');
 
-      exampleApp.path = '/user';
+      setLocation('/user');
       exampleApp.set('userData.page', 'details');
-      expect(exampleApp.path).to.be.eq('/user/details')
+      expect(window.location.pathname).to.be.eq('/user/details')
     });
   });
 </script>


### PR DESCRIPTION
This is enabled in `carbon-location` via the `useHashAsPath` property.
If this new property is `true`, `carbon-location` instances will refer
to the `hash` (as produced by `iron-page-url`) instead of the `path`
when configuring the `carbon-route-converter`.

Fixes #6.
