### PR TITLE
Add new boolean property named `active`

### DIFF
--- a/carbon-route.html
+++ b/carbon-route.html
@@ -120,6 +120,12 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         notify: true
       },
 
+      active: {
+        type: Boolean,
+        notify: true,
+        readOnly: true
+      },
+
       _skipMatch: {
         value: false
       },
@@ -165,6 +171,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       var namedMatches = {};
 
       var clearProperties = function clearProperties() {
+        this._setActive(false);
         this._matched = null;
         // this.tail = null;
         // this.data = {};
@@ -210,11 +217,12 @@ the `carbon-route` will update `route.path`. This in-turn will update the
           queryParams: this.route.queryParams
         };
       }
+      this._setActive(true);
       this._skipMatch = false;
     },
 
     __tailPathChanged: function(path) {
-      if (!this._matched || this._skipMatch) {
+      if (!this.active || this._skipMatch) {
         return;
       }
       var newPath = this._matched;
@@ -228,7 +236,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
     },
 
     __updatePathOnDataChange: function() {
-      if (!this.route || this._skipMatch || !this._matched) {
+      if (!this.route || this._skipMatch || !this.active) {
         return;
       }
       this._skipMatch = true;

--- a/test/carbon-route.html
+++ b/test/carbon-route.html
@@ -69,18 +69,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       };
 
       expect(route.data).to.be.deep.equal({username: 'sans'});
+      expect(route.active).to.be.equal(true);
 
       route.pattern = '/user/:username/likes/:count';
 
       // At the moment, we don't reset data when we no longer match.
       expect(route.data).to.be.deep.equal({username: 'sans'});
+      expect(route.active).to.be.equal(false);
 
       route.set('route.path', "/does/not/match");
 
       expect(route.data).to.be.deep.equal({username: 'sans'});
+      expect(route.active).to.be.equal(false);
 
       route.set('route.path', '/user/undyne/likes/20');
       expect(route.data).to.be.deep.equal({username: 'undyne', count: '20'});
+      expect(route.active).to.be.equal(true);
     });
 
     test('changing data changes the path', function() {


### PR DESCRIPTION
Useful for reacting to when a route matches or doesn't.

This came up in the explainer.
