### PR TITLE
Reset properties when route does not match.

### DIFF
--- a/carbon-route.html
+++ b/carbon-route.html
@@ -160,22 +160,28 @@ the `carbon-route` will update `route.path`. This in-turn will update the
       }
     },
 
+    __resetProperties: function() {
+      this._setActive(false);
+      this._matched = null;
+      this.tail = { path: null, prefix: null, queryParams: null };
+      //this.data = {};
+    },
+
     __tryToMatch: function(path, pattern) {
-      if (this._skipMatch || !path || !pattern) {
+      if (this._skipMatch || !pattern) {
         return;
       }
+
+      if (!path) {
+        this.__resetProperties();
+        return;
+      }
+
       var remainingPieces = path.split('/');
       var patternPieces = pattern.split('/');
 
       var matched = [];
       var namedMatches = {};
-
-      var clearProperties = function clearProperties() {
-        this._setActive(false);
-        this._matched = null;
-        // this.tail = null;
-        // this.data = {};
-      }.bind(this);
 
       for (var i=0; i < patternPieces.length; i++) {
         var patternPiece = patternPieces[i];
@@ -186,7 +192,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
 
         // We don't match this path.
         if (!pathPiece && pathPiece !== '') {
-          clearProperties();
+          this.__resetProperties();
           return;
         }
         matched.push(pathPiece);
@@ -194,7 +200,7 @@ the `carbon-route` will update `route.path`. This in-turn will update the
         if (patternPiece.charAt(0) == ':') {
           namedMatches[patternPiece.slice(1)] = pathPiece;
         } else if (patternPiece !== pathPiece) {
-          clearProperties();
+          this.__resetProperties();
           return;
         }
       }

--- a/test/carbon-route.html
+++ b/test/carbon-route.html
@@ -24,13 +24,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </carbon-route>
     </template>
   </test-fixture>
-
 <script>
   'use strict';
 
   suite('<carbon-route>', function () {
+    var route;
+
+    setup(function() {
+      route = fixture('BasicRoute');
+    });
+
     test('it parses a path', function() {
-      var route = fixture('BasicRoute');
       route.route = {
         prefix: '',
         path: '/user/papyrus/details',
@@ -43,7 +47,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('it bidirectionally maps changes between tail and route', function() {
-      var route = fixture('BasicRoute');
       route.route = {
         prefix: '',
         path: '/user/papyrus/details',
@@ -61,8 +64,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('it creates data as described by pattern', function() {
-      var route = fixture('BasicRoute');
-
       route.route = {
         prefix: '',
         path: '/user/sans'
@@ -88,8 +89,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('changing data changes the path', function() {
-      var route = fixture('BasicRoute');
-
       route.route = {
         prefix: '',
         path: '/user/asgore'
@@ -100,15 +99,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       expect(route.route.path).to.be.equal('/user/toriel');
     });
 
-    test('changing data on an inactive route won\'t change the path', function() {
-      var route = fixture('BasicRoute');
+    suite('when the pattern no longer matches', function() {
+      setup(function() {
+        route.route = {
+          prefix: '',
+          path: '/username/flowey'
+        };
 
-      route.route = {
-        prefix: '',
-        path: '/does/not/match'
-      };
-      route.data = {username: 'undyne'};
-      expect(route.route.path).to.be.equal('/does/not/match');
+        route.route = {
+          prefix: '',
+          path: '/does/not/match'
+        };
+      });
+
+      test('does not change path when data changes', function() {
+        route.data = {username: 'undyne'};
+        expect(route.route.path).to.be.equal('/does/not/match');
+      });
+
+      test('sets route to inactive', function() {
+        expect(route.active).to.be.equal(false);
+      });
+
+      test('resets tail', function() {
+        expect(route.tail).to.be.deep.equal({
+          path: null,
+          prefix: null,
+          queryParams: null
+        });
+      });
     });
   });
 </script>


### PR DESCRIPTION
Proposal:
When a route no longer matches, the `tail` property is re-initialized
and the `active` property is set to `false`.

Fixes #38 
