### PR TITLE
Only linkPaths one direction.

### DIFF
--- a/carbon-route-converter-behavior.html
+++ b/carbon-route-converter-behavior.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../polymer/polymer.html">
 <script>
   'use strict';
 
@@ -55,7 +56,6 @@
 
     created: function() {
       this.linkPaths('route.__queryParams', 'queryParams');
-      this.linkPaths('queryParams', 'route.__queryParams');
     },
 
     /**

--- a/carbon-route.html
+++ b/carbon-route.html
@@ -168,7 +168,6 @@ the `carbon-route` will update `route.path`. This in-turn will update the
 
     created: function() {
       this.linkPaths('route.__queryParams', 'tail.__queryParams');
-      this.linkPaths('tail.__queryParams', 'route.__queryParams');
     },
 
     // IE Object.assign polyfill


### PR DESCRIPTION
Also add a Polymer import to the behavior, as we write it to a field on the Polymer object.
