### PR TITLE
Don't generate excess query-params-changed events.

### DIFF
--- a/app-route.html
+++ b/app-route.html
@@ -172,20 +172,6 @@ the `app-route` will update `route.path`. This in-turn will update the
       this.linkPaths('tail.__queryParams', 'route.__queryParams');
     },
 
-    // IE Object.assign polyfill
-    __assign: function(target, source) {
-      if (Object.assign) {
-        return Object.assign(target, source);
-      }
-      if (source != null) {
-        for (var key in source) {
-          target[key] = source[key];
-        }
-      }
-
-      return target;
-    },
-
     /**
      * Deal with the query params object being assigned to wholesale.
      * @export
@@ -198,8 +184,31 @@ the `app-route` will update `route.path`. This in-turn will update the
           return;
         }
 
+        // Copy queryParams and track whether there are any differences compared
+        // to the existing query params.
+        var copyOfQueryParams = {};
+        var anythingChanged = false;
+        for (var key in queryParams) {
+          copyOfQueryParams[key] = queryParams[key];
+          if (anythingChanged ||
+              !this.queryParams ||
+              queryParams[key] !== this.queryParams[key]) {
+            anythingChanged = true;
+          }
+        }
+        // Need to check whether any keys were deleted
+        for (var key in this.queryParams) {
+          if (anythingChanged || !(key in queryParams)) {
+            anythingChanged = true;
+            break;
+          }
+        }
+
+        if (!anythingChanged) {
+          return;
+        }
         this._queryParamsUpdating = true;
-        this.set('queryParams', this.__assign({}, queryParams));
+        this.set('queryParams', copyOfQueryParams);
         this._queryParamsUpdating = false;
       }
     },

--- a/test/app-route.html
+++ b/test/app-route.html
@@ -274,6 +274,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(routes.bar.queryParams).to.be.eql({ qux: 'zot' });
           expect(routes.baz.queryParams).to.be.eql({ qux: 'quux' });
         });
+
+        test('doesn\'t generate excess query-params-changed events', function() {
+          var routes = fixtureChainedRoutes({});
+          var appRoutes = [routes.foo, routes.bar, routes.baz];
+          var numChanges = 0;
+          for (var i = 0; i < appRoutes.length; i++) {
+            appRoutes[i].addEventListener('query-params-changed', function() {
+              numChanges++;
+            });
+          }
+
+          // Messing with paths but not query params shouldn't generate any
+          // change events.
+          expect(numChanges).to.be.equal(0);
+          routes.foo.set('route.path', '/foo/123/bar/456');
+          expect(numChanges).to.be.equal(0);
+          routes.foo.set('route.path', '/foo/456/baz/789');
+          expect(numChanges).to.be.equal(0);
+
+          // Changing queryParams here should update foo and baz
+          routes.foo.set('route.__queryParams', {key: 'value'});
+          expect(numChanges).to.be.equal(2);
+          // Then this should update bar
+          routes.foo.set('route.path', '/foo/123/bar/456');
+          expect(numChanges).to.be.equal(3);
+
+          // Changing back to baz shouldn't generate a change event.
+          routes.foo.set('route.path', '/foo/456/baz/789');
+          expect(numChanges).to.be.equal(3);
+
+          routes.foo.set('route.__queryParams', {});
+          expect(numChanges).to.be.equal(5);
+          routes.foo.set('route.path', '/foo/123/bar/456');
+          expect(numChanges).to.be.equal(6);
+
+        });
       });
     });
 


### PR DESCRIPTION
Because we copy `queryParams` to prevent changes to inactive routes propagating back up, we generate excessive query-params-changed events.

This PR compares the copy against the original and skips doing the assignment if they are (shallowly) equal.