### PR TITLE
Fixes problem reported in #109

### DIFF
--- a/app-route.html
+++ b/app-route.html
@@ -326,11 +326,11 @@ the `app-route` will update `route.path`. This in-turn will update the
       /**
        * @export
        */
-      __tailPathChanged: function() {
+      __tailPathChanged: function(path) {
         if (!this.active) {
           return;
         }
-        var tailPath = this.tail.path;
+        var tailPath = path;
         var newPath = this._matched;
         if (tailPath) {
           if (tailPath.charAt(0) !== '/') {
@@ -396,11 +396,20 @@ the `app-route` will update `route.path`. This in-turn will update the
         for (var property in setObj) {
           this._propertySetter(property, setObj[property]);
         }
-
-        for (var property in setObj) {
-          this._pathEffector(property, this[property]);
-          this._notifyChange(property);
+        //notify in a specific order
+        if (setObj.data !== undefined) {
+          this._pathEffector('data', this.data);
+          this._notifyChange('data');
         }
+        if (setObj.active !== undefined) {
+          this._pathEffector('active', this.active);
+          this._notifyChange('active');
+        }
+        if (setObj.tail !== undefined) {
+          this._pathEffector('tail', this.tail);
+          this._notifyChange('tail');
+        }
+
       }
     });
   })();

--- a/app-route.html
+++ b/app-route.html
@@ -399,14 +399,7 @@ the `app-route` will update `route.path`. This in-turn will update the
 
         for (var property in setObj) {
           this._pathEffector(property, this[property]);
-          var rootName = this._modelForPath(property);
-          var dashCaseName = Polymer.CaseMap.camelToDashCase(rootName);
-          var eventName = dashCaseName + this._EVENT_CHANGED;
-          // use a cached event here (_useCache: true) for efficiency
-          this.fire(eventName, {
-            value: this[property]
-          }, {bubbles: false});
-
+          this._notifyChange(property);
         }
       }
     });

--- a/app-route.html
+++ b/app-route.html
@@ -399,7 +399,14 @@ the `app-route` will update `route.path`. This in-turn will update the
 
         for (var property in setObj) {
           this._pathEffector(property, this[property]);
-          this._notifyPathUp(property, this[property]);
+          var rootName = this._modelForPath(property);
+          var dashCaseName = Polymer.CaseMap.camelToDashCase(rootName);
+          var eventName = dashCaseName + this._EVENT_CHANGED;
+          // use a cached event here (_useCache: true) for efficiency
+          this.fire(eventName, {
+            value: this[property]
+          }, {bubbles: false});
+
         }
       }
     });

--- a/test/index.html
+++ b/test/index.html
@@ -20,7 +20,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'app-route-converter.html',
         'app-route.html',
         'app-location.html',
+        'test-observer-app.html',
         'test-app-example-1.html',
+
       ]);
     </script>
   </body>

--- a/test/observer-tester.html
+++ b/test/observer-tester.html
@@ -1,0 +1,38 @@
+  <link rel='import' href='../app-route.html'>
+  <link rel='import' href='../app-location.html'>
+
+
+
+  <dom-module id="observer-tester">
+    <template>
+      <app-location route="{{route}}"></app-location>
+      <app-route
+        route="{{route}}"
+        pattern="/report/:id"
+        data="{{data}}"
+        active="{{active}}"></app-route>
+    </template>
+    <script>
+      Polymer({
+        is: 'observer-tester',
+        properties: {
+          route: {
+            type: Object,
+            notify:true
+          },
+          data: {
+            type: Object,
+            notify: true
+          },
+          active: {
+            type: Boolean,
+            value: false,
+            observer: 'checkActive'
+          }
+        },
+        checkActive: function(active) {
+          var x = 1;
+        }
+      });
+    </script>
+  </dom-module>

--- a/test/test-observer-app.html
+++ b/test/test-observer-app.html
@@ -1,0 +1,58 @@
+<!doctype html>
+
+<html>
+<head>
+  <title>app-route 0bserver Test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="./observer-tester.html">
+
+</head>
+<body>
+
+  <test-fixture id="observer_app">
+    <template>
+      <observer-tester id="testel"></observer-tester>
+    </template>
+  </test-fixture>
+  <script>
+  'use strict';
+    function setLocation(url) {
+      window.history.pushState({}, '', url);
+      Polymer.Base.fire('location-changed', {}, { node: window });
+    }
+
+
+    suite('observe app-route active changes', function(){
+      var originalLocation;
+      var sandbox, el;
+      setup(function(){
+        originalLocation = window.location.href;
+        sandbox = sinon.sandbox.create();
+        el = fixture('observer_app');
+     });
+      teardown(function(){
+        sandbox.restore();
+        window.history.replaceState({}, '', originalLocation);
+      });
+
+      test('observer should fire when route selected', function(){
+        sandbox.spy(el,'checkActive');
+        setLocation('/report/1000');
+        expect(el.checkActive).to.have.been.called.once;
+        expect(el.checkActive).to.have.been.calledWith(true);
+      });
+      test('observer should fire when route deselected',function(){
+        setLocation('/report/1000');
+        sandbox.spy(el,'checkActive');
+        setLocation('/menu');
+        expect(el.checkActive).to.have.been.called.once;
+        expect(el.checkActive).to.have.been.calledWith(false);
+      });
+    });
+  </script>
+</body>
+


### PR DESCRIPTION
This fixes the issue where transitions to true for the active property did not properly
propagate - and cause the observer to be called, when set via the this.__setMulti function.

Includes tests which fail before this fix but pass afterwards.
