### PR TITLE
Fix closing tag github issue 143

### DIFF
--- a/demo/data-loading-demo/flickr-search-demo.html
+++ b/demo/data-loading-demo/flickr-search-demo.html
@@ -43,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                           route="{{searchRoute}}">
       </flickr-search-page>
       <flickr-image-page id="image" api-key="{{apiKey}}" route="{{imageRoute}}">
-      </flickr-search-page>
+      </flickr-image-page>
     </iron-pages>
   </template>
   <script>


### PR DESCRIPTION
fix closing tag line 46 of flickr-search-demo.html, references https://github.com/PolymerElements/app-route/issues/143