### PR TITLE
Make queryParams property definition public

### DIFF
--- a/app-location.html
+++ b/app-location.html
@@ -132,7 +132,7 @@ firing a `location-changed` event on `window`. i.e.
            * A set of key/value pairs that are universally accessible to branches
            * of the route tree.
            */
-          __queryParams: {
+          queryParams: {
             type: Object
           },
 


### PR DESCRIPTION
I think the double underscore was added by mistake. In the template it is used without.