### PR TITLE
Fix documentation error location.pushState

### DIFF
--- a/app-location.html
+++ b/app-location.html
@@ -55,7 +55,7 @@ location. It also listens for that same event, and re-reads the URL when it's
 fired. This makes it very easy to interop with other routing code.
 
 So for example if you want to navigate to `/new_path` imperatively you could
-call `window.location.pushState` or `window.location.replaceState` followed by
+call `window.history.pushState` or `window.history.replaceState` followed by
 firing a `location-changed` event on `window`. i.e.
 
     window.history.pushState({}, null, '/new_path');


### PR DESCRIPTION
Documentation says window.location.pushState but the correct path should be window.history.pushState. (Noticed the guidelines says there should be an issue for each pull request but I'm already here and didn't create an issue for it nor found one)