### PR TITLE
Declare the `route` property on flickr demo pages.

### DIFF
--- a/demo/data-loading-demo/flickr-image-page.html
+++ b/demo/data-loading-demo/flickr-image-page.html
@@ -73,8 +73,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         params: {
           type: Object,
           computed: '_computeParams(apiKey, data.id, data.secret)'
-        }
+        },
 
+        route: {
+          type: Object
+        }
       },
       observers: [
         '_clearOldMetadata(route.path)'

--- a/demo/data-loading-demo/flickr-search-page.html
+++ b/demo/data-loading-demo/flickr-search-page.html
@@ -62,6 +62,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           type: Object,
           computed: '_computeParams(apiKey, queryParams.search)'
         },
+
+        route: {
+          type: Object
+        }
       },
 
       observers: [


### PR DESCRIPTION
It's part of their public API.

Found while developing the new linter.