### PR TITLE
Remove reference to unknown observer function.

### DIFF
--- a/demo/youtube-demo/youtube-search.html
+++ b/demo/youtube-demo/youtube-search.html
@@ -64,8 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         category: {
           type: String,
-          notify: true,
-          observer: '_categoryChanged'
+          notify: true
         },
 
         params: {


### PR DESCRIPTION
The referenced function doesn't exist anywhere in the repo, probably a leftover from a previous version of the file.

Found while developing the new linter.