### PR TITLE
posibility to add optional parameters

### DIFF
--- a/app-route.html
+++ b/app-route.html
@@ -253,14 +253,9 @@ the `app-route` will update `route.path`. This in-turn will update the
         if (!this.route) {
           return;
         }
-        var path = this.route.path;
+        var path = this.route.path || "";
         var pattern = this.pattern;
         if (!pattern) {
-          return;
-        }
-
-        if (!path) {
-          this.__resetProperties();
           return;
         }
 
@@ -276,17 +271,25 @@ the `app-route` will update `route.path`. This in-turn will update the
             break;
           }
           var pathPiece = remainingPieces.shift();
+          var patternPieceOptional = false;
 
-          // We don't match this path.
-          if (!pathPiece && pathPiece !== '') {
+          if (patternPiece.slice(-1) == '?') {
+            // Optional parameter.
+            patternPiece = patternPiece.slice(0, -1);
+            patternPieceOptional = true;
+          } else if (!pathPiece && pathPiece !== '') {
+            // No optional parameter and we don't match this path.
             this.__resetProperties();
             return;
           }
-          matched.push(pathPiece);
+
+          if (pathPiece !== undefined) {
+            matched.push(pathPiece);
+          }
 
           if (patternPiece.charAt(0) == ':') {
             namedMatches[patternPiece.slice(1)] = pathPiece;
-          } else if (patternPiece !== pathPiece) {
+          } else if (patternPiece !== pathPiece && !patternPieceOptional) {
             this.__resetProperties();
             return;
           }


### PR DESCRIPTION
We have the possibility to add optional parameters in the pattern attribute with the ```?``` character at the end.
In this example:
```
    <app-route
      active="{{active}}"
      route="{{route}}"
      pattern="/client/:id?"
      data="{{routeData}}"
      tail="{{subroute}}"></app-route>
```
The path ```/client``` matches the route, setting ```routeData.id``` to ```undefined``` and ```active``` to ```true```. If pattern would be ```/client/:id```, this path wouldn't matches the route. With the pattern of the example above, the path ```/client/c123``` also matches the route, with ```routeData.id``` equal to ```c123```.

A more complicated example would be the same app-route element with pattern attribute ```pattern="/client/:id?/:action?"```. The paths ```/client```, ```/client/```, ```/client/c123```, ```/client/123/overview``` also matches the route. Supossing second path (```/client/```), ```routeData``` would be ```{'id': '', 'action': undefined}```

This feature also works with fixed patterns without parameters (i.e. ```pattern="/client/list?").