### PR TITLE
Documentation fix: window.location should be window.history

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ location. It also listens for that same event, and re-reads the URL when it's
 fired. This makes it very easy to interop with other routing code.
 
 So for example if you want to navigate to `/new_path` imperatively you could
-call `window.location.pushState` or `window.location.replaceState` followed by
+call `window.history.pushState` or `window.history.replaceState` followed by
 firing a `location-changed` event on `window`. i.e.
 
 ```javascript


### PR DESCRIPTION
Looks like this was actually previously fixed via 70d9799 but it was then reverted by tedium-bot when it autogenerated the README file in 2e2fa64.

It's unclear to me from the outside how tedium-bot did the autogeneration, so if there is another spot I need to make this change (and I can access it), let me know.