### PR TITLE
from polymerelements to PolymerElements (again)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,16 +20,16 @@
   },
   "devDependencies": {
     "google-youtube": "GoogleWebComponents/google-youtube#1 - 2",
-    "iron-component-page": "polymerelements/iron-component-page#1 - 2",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "iron-pages": "PolymerElements/iron-pages#1 - 2",
-    "iron-test-helpers": "polymerelements/iron-test-helpers#1 - 2",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#1 - 2",
     "paper-card": "PolymerElements/paper-card#1 - 2",
-    "paper-icon-button": "polymerelements/paper-icon-button#1 - 2",
-    "paper-input": "polymerelements/paper-input#1 - 2",
+    "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
+    "paper-input": "PolymerElements/paper-input#1 - 2",
     "paper-spinner": "PolymerElements/paper-spinner#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
-    "paper-toggle-button": "polymerelements/paper-toggle-button#1 - 2",
+    "paper-toggle-button": "PolymerElements/paper-toggle-button#1 - 2",
     "url": "webcomponents/URL#^0.5.7",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
@@ -37,21 +37,21 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "iron-location": "polymerelements/iron-location#^0.8.1",
+        "iron-location": "PolymerElements/iron-location#^0.8.1",
         "polymer": "Polymer/polymer#^1.9"
       },
       "devDependencies": {
         "google-youtube": "GoogleWebComponents/google-youtube#^1.2.1",
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
         "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.2.0",
         "iron-pages": "PolymerElements/iron-pages#^1.0.7",
-        "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
+        "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
         "paper-card": "PolymerElements/paper-card#^1.1.1",
-        "paper-icon-button": "polymerelements/paper-icon-button#^v1.0.0",
-        "paper-input": "polymerelements/paper-input#^1.1.2",
+        "paper-icon-button": "PolymerElements/paper-icon-button#^v1.0.0",
+        "paper-input": "PolymerElements/paper-input#^1.1.2",
         "paper-spinner": "PolymerElements/paper-spinner#^1.1.1",
-        "paper-styles": "polymerelements/paper-styles#^1.0.13",
-        "paper-toggle-button": "polymerelements/paper-toggle-button#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.13",
+        "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.0",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },


### PR DESCRIPTION
This is a similar pull request to #174. I assume that when you merged your 2.0-preview branch into master, you have overwritten the changes again. This time I also covered the "devDependencies". Below is a copy-and-paste of the rational of this change:

This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.