### PR TITLE
Fix: query parameters are getting removed

### DIFF
--- a/app-location.html
+++ b/app-location.html
@@ -66,16 +66,16 @@ firing a `location-changed` event on `window`. i.e.
 -->
 <dom-module id="app-location">
   <template>
+    <iron-query-params
+        params-string="{{__query}}"
+        params-object="{{queryParams}}">
+    </iron-query-params>
     <iron-location
         path="{{__path}}"
         query="{{__query}}"
         hash="{{__hash}}"
         url-space-regex={{urlSpaceRegex}}>
     </iron-location>
-    <iron-query-params
-        params-string="{{__query}}"
-        params-object="{{queryParams}}">
-    </iron-query-params>
   </template>
   <script>
     (function() {


### PR DESCRIPTION
Turns out that when you have two elements both setting defaults the one that comes later in the DOM is the one that wins out, in this case iron-query-params comes later and sets defaults that then cause the queryParams to get set to an empty string and updates iron-location to remove params from the URL.

This isn't a proper solution to the problem, but I couldn't figure out a non-breaking way to handle it in iron-location, this at leasts allows users to start using queryParams in their apps again...tried to test but turns out the way the test environment handles flushing makes this a case I couldn't trigger.

Addresses:
https://github.com/PolymerElements/iron-location/pull/83
https://github.com/PolymerElements/iron-location/pull/86