### PR TITLE
Exposes dwellTime

### DIFF
--- a/app-location.html
+++ b/app-location.html
@@ -74,7 +74,8 @@ firing a `location-changed` event on `window`. i.e.
         path="{{__path}}"
         query="{{__query}}"
         hash="{{__hash}}"
-        url-space-regex={{urlSpaceRegex}}>
+        url-space-regex={{urlSpaceRegex}}
+        dwell-time={{dwellTime}}>
     </iron-location>
   </template>
   <script>
@@ -171,6 +172,18 @@ firing a `location-changed` event on `window`. i.e.
            */
           _isReady: {
             type: Boolean
+          },
+          /**
+           * If the user was on a URL for less than `dwellTime` milliseconds, it
+           * won't be added to the browser's history, but instead will be replaced
+           * by the next entry.
+           *
+           * This is to prevent large numbers of entries from clogging up the user's
+           * browser history. Disable by setting to a negative number.
+           */
+          dwellTime: {
+            type: Number,
+            value: 2000
           }
         },
 


### PR DESCRIPTION
If the user was on a URL for less than `dwellTime` milliseconds, it won't be added to the browser's history, but instead will be replaced  by the next entry.