### PR TITLE
setting active is now atomic

### DIFF
--- a/app-route.html
+++ b/app-route.html
@@ -318,11 +318,8 @@ the `app-route` will update `route.path`. This in-turn will update the
         }
 
         if (this.setProperties) {
-          if (!this.active) {
-            this._setActive(true);
-          }
           // atomic update
-          this.setProperties(propertyUpdates);
+          this.setProperties(propertyUpdates, true);
         } else {
           this.__setMulti(propertyUpdates);
         }

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "paper-styles": "PolymerElements/paper-styles#1 - 2",
     "paper-toggle-button": "polymerelements/paper-toggle-button#1 - 2",
     "url": "webcomponents/URL#^0.5.7",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "^6.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
@@ -52,7 +52,7 @@
         "paper-spinner": "PolymerElements/paper-spinner#^1.1.1",
         "paper-styles": "polymerelements/paper-styles#^1.0.13",
         "paper-toggle-button": "polymerelements/paper-toggle-button#^1.0.0",
-        "web-component-tester": "^4.0.0",
+        "web-component-tester": "^6.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },
       "resolutions": {

--- a/test/app-route.html
+++ b/test/app-route.html
@@ -195,6 +195,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     suite('propagating data', function() {
+      test('data is defined when active is true', function(done) {
+        var chainedRoutes = fixture('ChainedRoutes');
+
+        chainedRoutes.$.foo.addEventListener('active-changed', function(e) {
+          if (e.detail.value = true) {
+            expect(chainedRoutes.$.foo.data.foo).to.be.equal('bar');
+            done();
+          }
+        });
+
+        chainedRoutes.$.foo.route = {
+          prefix: '',
+          path: '/foo/bar',
+          __queryParams: {}
+        };
+      });
       test('data is empty if no routes in the tree have matched', function() {
         var routes = fixtureChainedRoutes({ path: '' });
 


### PR DESCRIPTION
Seems like core pulled through with my feature request. Read-only props can now be set atomically.

Fixes #185.
Fixes #168.
Fixes #148.