### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/app-route-converter.js
+++ b/app-route-converter.js
@@ -72,6 +72,7 @@ turn is consumed by the `app-route`.
 */
 Polymer({
   is: 'app-route-converter',
+  _template: null,
 
   behaviors: [AppRouteConverterBehavior]
 });

--- a/app-route.js
+++ b/app-route.js
@@ -84,6 +84,7 @@ the `app-route` will update `route.path`. This in-turn will update the
 */
 Polymer({
   is: 'app-route',
+  _template: null,
 
   properties: {
     /**


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336